### PR TITLE
Fix dark theme text color for mobile

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -1674,6 +1674,27 @@
             right: 15%;
             bottom: 25%;
         }
+        
+        /* Mobile-specific dark mode text fixes */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .author-info p {
+            color: #FFFFFF !important;
+        }
     }
     
     @media (max-width: 480px) {
@@ -1692,6 +1713,27 @@
             justify-content: center;
             padding: 0.75rem 1.5rem;
             font-size: 0.9rem;
+        }
+        
+        /* Additional mobile-specific dark mode text fixes for smaller screens */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .author-info p {
+            color: #FFFFFF !important;
         }
     }
     

--- a/css/contact.css
+++ b/css/contact.css
@@ -1432,6 +1432,30 @@ body.dark-mode .faq-answer p {
         align-items: flex-start;
     }
     
+    /* Mobile-specific dark mode text fixes */
+    body.dark-mode .hero-subtitle {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .section-subtitle {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .service-description {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .step-description {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .author-info p {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .contact-hero-subtitle {
+        color: #FFFFFF !important;
+    }
     
 
 }
@@ -1450,6 +1474,30 @@ body.dark-mode .faq-answer p {
         grid-template-columns: 1fr;
     }
     
+    /* Additional mobile-specific dark mode text fixes for smaller screens */
+    body.dark-mode .hero-subtitle {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .section-subtitle {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .service-description {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .step-description {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .author-info p {
+        color: #FFFFFF !important;
+    }
+    
+    body.dark-mode .contact-hero-subtitle {
+        color: #FFFFFF !important;
+    }
     
 
 }

--- a/css/inquiry.css
+++ b/css/inquiry.css
@@ -1636,6 +1636,31 @@ body.dark-mode .template-btn:hover {
             flex-direction: column;
             align-items: flex-start;
         }
+        
+        /* Mobile-specific dark mode text fixes */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .benefit-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .form-label {
+            color: #FFFFFF !important;
+        }
     }
 
     @media (max-width: 480px) {
@@ -1683,6 +1708,31 @@ body.dark-mode .template-btn:hover {
         
         .newsletter-btn {
             justify-content: center;
+        }
+        
+        /* Additional mobile-specific dark mode text fixes for smaller screens */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .benefit-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .form-label {
+            color: #FFFFFF !important;
         }
     }
 

--- a/css/main.css
+++ b/css/main.css
@@ -2177,6 +2177,27 @@
         .hero {
             padding-top: 70px;
         }
+        
+        /* Mobile-specific dark mode text fixes */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .author-info p {
+            color: #FFFFFF !important;
+        }
     }
     
     @media (max-width: 480px) {
@@ -2214,6 +2235,27 @@
         
         .logo img, .logo-img {
             height: 40px;
+        }
+        
+        /* Additional mobile-specific dark mode text fixes for smaller screens */
+        body.dark-mode .hero-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .section-subtitle {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .service-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .step-description {
+            color: #FFFFFF !important;
+        }
+        
+        body.dark-mode .author-info p {
+            color: #FFFFFF !important;
         }
         
         .theme-toggle, .mobile-menu-btn {

--- a/css/services.css
+++ b/css/services.css
@@ -1339,6 +1339,27 @@
             .hero {
                 padding-top: 70px;
             }
+            
+            /* Mobile-specific dark mode text fixes */
+            body.dark-mode .hero-subtitle {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .section-subtitle {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .service-description {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .step-description {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .faq-answer p {
+                color: #FFFFFF !important;
+            }
         }
         
         @media (max-width: 480px) {
@@ -1408,6 +1429,27 @@
             
             .hero {
                 padding-top: 65px;
+            }
+            
+            /* Additional mobile-specific dark mode text fixes for smaller screens */
+            body.dark-mode .hero-subtitle {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .section-subtitle {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .service-description {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .step-description {
+                color: #FFFFFF !important;
+            }
+            
+            body.dark-mode .faq-answer p {
+                color: #FFFFFF !important;
             }
         }
         


### PR DESCRIPTION
Change gray text to white in dark mode on mobile for improved visibility, without affecting light theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-49cf9b4f-9b25-40b9-8414-6b2afd085ac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49cf9b4f-9b25-40b9-8414-6b2afd085ac1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

